### PR TITLE
Add support for passthrough columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ vars:
     shopify_database: your_schema_name
 ```
 
+This package includes all source columns defined in the staging_columns.sql macro. To add additional columns to this package, do so using our pass-through column variables. This is extremely useful if you'd like to include custom fields to the package.
+
+```yml
+# dbt_project.yml
+
+...
+config-version: 2
+
+vars:
+  shopify_source:
+    customer_pass_through_columns: []
+    order_line_refund_pass_through_columns: []
+    order_line_pass_through_columns: []
+    order_pass_through_columns: []
+    product_pass_through_columns: []
+```
+
 ## Contributions
 
 Additional contributions to this package are very welcome! Please create issues

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -17,3 +17,8 @@ vars:
     order_line_source: "{{ source('shopify','order_line') }}"
     order_source: "{{ source('shopify','order') }}"
     product_source: "{{ source('shopify','product') }}"
+    customer_pass_through_columns: []
+    order_line_refund_pass_through_columns: []
+    order_line_pass_through_columns: []
+    order_pass_through_columns: []
+    product_pass_through_columns: []

--- a/models/stg_shopify__customer.sql
+++ b/models/stg_shopify__customer.sql
@@ -15,6 +15,13 @@ renamed as (
             )
         }}
 
+      --The below script allows for pass through columns.
+      {% if var('customer_pass_through_columns') %}
+      ,
+      {{ var('customer_pass_through_columns') | join (", ")}}
+
+      {% endif %}
+
     from source
 
 )

--- a/models/stg_shopify__order.sql
+++ b/models/stg_shopify__order.sql
@@ -15,6 +15,13 @@ renamed as (
             )
         }}
 
+      --The below script allows for pass through columns.
+      {% if var('order_pass_through_columns') %}
+      ,
+      {{ var('order_pass_through_columns') | join (", ")}}
+
+      {% endif %}
+
     from source
 
 )

--- a/models/stg_shopify__order_line.sql
+++ b/models/stg_shopify__order_line.sql
@@ -15,6 +15,13 @@ renamed as (
             )
         }}
 
+      --The below script allows for pass through columns.
+      {% if var('order_line_pass_through_columns') %}
+      ,
+      {{ var('order_line_pass_through_columns') | join (", ")}}
+
+      {% endif %}
+
     from source
 
 )

--- a/models/stg_shopify__order_line_refund.sql
+++ b/models/stg_shopify__order_line_refund.sql
@@ -15,6 +15,13 @@ renamed as (
             )
         }}
 
+      --The below script allows for pass through columns.
+      {% if var('order_line_refund_pass_through_columns') %}
+      ,
+      {{ var('order_line_refund_pass_through_columns') | join (", ")}}
+
+      {% endif %}
+
     from source
 
 )

--- a/models/stg_shopify__product.sql
+++ b/models/stg_shopify__product.sql
@@ -15,6 +15,13 @@ renamed as (
             )
         }}
 
+      --The below script allows for pass through columns.
+      {% if var('product_pass_through_columns') %}
+      ,
+      {{ var('product_pass_through_columns') | join (", ")}}
+
+      {% endif %}
+
     from source
 
 )


### PR DESCRIPTION
This PR adds support for passthrough columns in each model, borrowing the pattern from the dbt_salesforce_source package, as discussed in issue #7.

No change is required in the dbt_shopify transform package since all models are doing `select *`, so the columns are included automatically in the final models.

I've tested this change successfully after introducing a custom field in base models, adding a shop identifier while unioning multiple Shopify instances.