### PR TITLE
Rename state column in customer model to avoid ambiguity

### DIFF
--- a/macros/staging_columns.sql
+++ b/macros/staging_columns.sql
@@ -86,7 +86,7 @@
     {"name": "last_name", "datatype": dbt_utils.type_string()},
     {"name": "orders_count", "datatype": dbt_utils.type_numeric()},
     {"name": "phone", "datatype": dbt_utils.type_string()},
-    {"name": "state", "datatype": dbt_utils.type_string()},
+    {"name": "state", "datatype": dbt_utils.type_string(), "alias": "account_state"},
     {"name": "tax_exempt", "datatype": "boolean", "alias": "is_tax_exempt"},
     {"name": "total_spent", "datatype": dbt_utils.type_float()},
     {"name": "updated_at", "datatype": dbt_utils.type_timestamp(), "alias": "updated_timestamp"},

--- a/models/stg_shopify.yml
+++ b/models/stg_shopify.yml
@@ -27,7 +27,7 @@ models:
         description: The number of orders associated with this customer.
       - name: phone
         description: The unique phone number (E.164 format) for this customer. Attempting to assign the same phone number to multiple customers returns an error.
-      - name: state
+      - name: account_state
         description: The state of the customer's account with a shop.
       - name: is_tax_exempt
         description: Whether the customer is exempt from paying taxes on their order. If true, then taxes won't be applied to an order at checkout. If false, then taxes will be applied at checkout.


### PR DESCRIPTION
Rename state column in customer model to avoid ambiguity with address-related state, as mentioned in issue #9.

See also related [PR 9](https://github.com/fivetran/dbt_shopify/pull/9) in the transform package.

Note that this is a breaking change.