### PR TITLE
Patch 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_shopify_source v0.8.2
+
+## Bug Fixes
+- Adjusts the test not_null_stg_shopify__discount_code_discount_code_id to warn instead of fail. If the source table discount_code does not exist the staging temp file creates a record and puts the discount_code_id as null. Doing so would cause the test to fail until a record is in that table.
+
 # dbt_shopify_source v0.8.1
 
 ## Bug Fixes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_source'
-version: '0.8.1'
+version: '0.8.2'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_source_integration_tests'
-version: '0.8.1'
+version: '0.8.2'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/stg_shopify.yml
+++ b/models/stg_shopify.yml
@@ -858,6 +858,8 @@ models:
         description: The ID for the discount code.
         tests:
           - not_null
+              config:
+                severity: warn
       - name: price_rule_id
         description: The ID for the price rule that this discount code belongs to.
       - name: updated_at


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Jared Carlisle, adMind LLC

**What change(s) does this PR introduce?** 
This changes the severity of a test on discount_code_id being null to warn. This is due to the fact that if the source table does not exist the code inserts a record where the discount_code_id is null, which would result in the test failing all the time.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)
- It is non-breaking because it just changes the severity of a test.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes, Issue/Feature [link bug/feature number here]
- [x] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] Buildkite). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Buildkite <!--- Buildkite testing is only applicable to Fivetran employees. --> 
- [ ] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
