### PR TITLE
Update accepted_values test in stg_shopify__fulfillment_event_status to include new 'delayed' status from Shopify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt_shopify_source v0.12.1
 
-[PR #](https://github.com/fivetran/dbt_shopify_source/pull/) introduces the following changes: 
+[PR #84](https://github.com/fivetran/dbt_shopify_source/pull/84) introduces the following changes: 
 
 ## 🪲 Bug Fixes 🪛
 - Added support for a new 'delayed' fulfillment event status from Shopify.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_shopify_source v0.12.1
+
+[PR #](https://github.com/fivetran/dbt_shopify_source/pull/) introduces the following changes: 
+
+## 🪲 Bug Fixes 🪛
+- Added support for a new 'delayed' fulfillment event status from Shopify.
+
 # dbt_shopify_source v0.12.0
 
 [PR #79](https://github.com/fivetran/dbt_shopify_source/pull/79) introduces the following changes: 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_source'
-version: '0.12.0'
+version: '0.12.1'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_source_integration_tests'
-version: '0.12.0'
+version: '0.12.1'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/stg_shopify.yml
+++ b/models/stg_shopify.yml
@@ -1668,7 +1668,7 @@ models:
           - failure: Something went wrong when pulling tracking information for the shipment, such as the tracking number was invalid or the shipment was canceled.
         tests:
           - accepted_values:
-              values:  ['attempted_delivery', 'delivered', 'failure', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'picked_up', 'label_printed', 'label_purchased', 'confirmed']
+              values:  ['attempted_delivery', 'delayed', 'delivered', 'failure', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'picked_up', 'label_printed', 'label_purchased', 'confirmed']
               config:
                 severity: warn # we pivot these out in shopify__daily_shop
       - name: updated_at


### PR DESCRIPTION
**Description**
Update test to include new 'delayed' status from Shopify.

Brent Shreve 
Onebridge - https://www.onebridge.tech/

**Link the issue/feature request which this PR is meant to address**
https://github.com/fivetran/dbt_shopify_source/issues/83

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**
This PR updates the existing accepted_values test for the stg_shopify__fulfillment_event_status model to include the new 'delayed' fulfillment status from Shopify.

**How did you validate the changes introduced within this PR?**
In a development and production environment where Fivetran and dbt are deployed for Shopify.

**Which warehouse did you use to develop these changes?**
Snowflake

**Did you update the CHANGELOG?**
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:pancakes: