### PR TITLE
bugfix/media-image-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_shopify_source v0.18.2
+
+## Bug Fixes
+- Removed the `not_null` test for the `image_id` field from the `stg_shopify__media_image` model as this field may be empty.
+
 # dbt_shopify_source v0.18.1
 
 [PR #103](https://github.com/fivetran/dbt_shopify_source/pull/103) includes the following updates:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_source'
-version: '0.18.1'
+version: '0.18.2'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'shopify_source_integration_tests'
-version: '0.18.1'
+version: '0.18.2'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/stg_shopify.yml
+++ b/models/stg_shopify.yml
@@ -1088,8 +1088,6 @@ models:
           - not_null
       - name: image_id
         description: Unique numeric identifier of the product image.
-        tests:
-          - not_null
       - name: image_alt_text
         description: A word or phrase to share the nature or contents of an image.
       - name: image_height


### PR DESCRIPTION
<!--
Pre-Submission Reminders  
Before marking this PR as "ready for review":

- `dbt run --full-refresh && dbt test`  
- `dbt run` && `dbt test` (if incremental models are present)  
- The related issue is linked, tagged, and appropriately assigned  
- Documentation and version updates are included, if applicable  
- `docs` have been regenerated (unless there are no code or YAML changes)  
- BuildKite integration tests are passing
-->

## PR Overview 
**Package version introduced in this PR:**  v0.18.2
 
**This PR addresses the following Issue/Feature(s):** Issue #102 
<!-- Add Issue # or internal ticket reference -->

**Summary of changes:**  
<!-- 1-2 sentences describing PR changes. -->

Removes the `not_null` test for the `image_id` field in the media_image staging model.

### Submission Checklist  
- [ ] Alignment meeting with the reviewer (if needed)  
  - [ ] Timeline and validation requirements discussed  
- [X] Provide validation details:  
  - [X] **Validation Steps:** Check for unintentional effects (e.g., add/run consistency & integrity tests)
     - Confirmed based on the [ERD](https://docs.google.com/presentation/d/1wSWI7SbY4NMtyRLWdg2Z4LW3-SRCF8K7McN0VzLjh3w/edit?slide=id.g35395cec934_2_0#slide=id.g35395cec934_2_0) that there's no indication that the `image_id` needs to be populated. The `media_id` is the PK and the test should remain there. But not necessary for the `image_id`.
     - Additionally, when inspecting the [API docs](https://shopify.dev/docs/api/admin-graphql/2024-10/objects/MediaImage) you can see the id field is not_null enforced, but image is able to be null if no image is available.
  - [X] **Testing Instructions:** Confirm the change addresses the issue(s)
     - Confirm the BK tests pass. 
  - [X] **Focus Areas:** Complex logic or queries that need extra attention  
     - No major focus areas to callout. 

### Changelog  
<!-- Recommend drafting changelog notes, then refining via ChatGPT using:  
"Draft a changelog entry based on the following notes." -->
- [X] Draft changelog for PR  
- [ ] Final changelog for release review